### PR TITLE
Passing mysqli stmt errno along in exception

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -281,7 +281,7 @@ abstract class BasicObject {
 		$stmt = $db->prepare($query);
 		call_user_func_array(array($stmt, 'bind_param'), $params);
 		if(!$stmt->execute()) {
-			throw new Exception("Internal error, failed to execute query:\n<pre>$query\n".$stmt->error.'</pre>');
+			throw new Exception("Internal error, failed to execute query:\n<pre>$query\n".$stmt->error.'</pre>', $stmt->errno);
 		}
 		$stmt->close();
 		if(!isset($this->_exists) || !$this->_exists){


### PR DESCRIPTION
The errno from mysqli stmt is sometimes useful.
Consider this block of code:

``` php
foreach($products as $p) {
    try {
        $p->add_tag($tag[0]);
    } catch(Exception $e) {
        // Just ignore duplicate entry exceptions
        if($e->getCode() == 1062) {
            continue;
        }
        throw $e;
    }
    $counter++;
}
```
