### PR TITLE
Adding exception for bad column names like "@order:desc"

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -594,7 +594,7 @@ abstract class BasicObject {
 						}
 						foreach($value as $o){
 							$desc = false;
-							if(substr($o,-5) == ':desc'){
+							if(strtolower(substr($o,-5)) == ':desc'){
 								$desc = true;
 								$o = substr($o, 0,-5);
 							}


### PR DESCRIPTION
Current code silently accepts "@order:desc", and it results in the same as "@order". It took me a while to figure out I needed to put :desc in the value, not the key.
Anything after : in the key name of special parameters is discarded, so I figure it would be better to throw an exception if : is found in the key.
