### PR TITLE
Fix bug where @and removes existing wheres

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -643,7 +643,7 @@ abstract class BasicObject {
 					case '@and':
 						$where = '';
 						$types .= self::handle_params($value, $joins, $where, $order, $table_name, $limit, $user_params, 'AND');
-						$wheres = "(\n".substr($where, 0, -5)."\n) $glue\n";
+						$wheres .= "(\n".substr($where, 0, -5)."\n) $glue\n";
 						break;
 					default:
 						throw new Exception("No such operator '".substr($column,1)."' (value '$value')");


### PR DESCRIPTION
Example:
array(
    'foo' => 1,
    '@and' => array(
        'bar' => 2,
        'baz' => 3
    )
)
Would give the query "bar = ? AND baz = ?"
 with params = [1, 2, 3]

Expected result would be "foo = ? AND ( bar = ? and baz = ? ) "
with params = [1, 2, 3].
