### PR TITLE
Fix PHP segfault when missing function `Class::table_name`.

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -122,7 +122,7 @@ abstract class BasicObject {
 				}
 			}
 		}
-		if(count($arguments) == 0){
+		if(count($arguments) == 0 && $name != 'table_name'){
 			try{
 				return $this->__get($name);
 			} catch(UndefinedMemberException $e) {


### PR DESCRIPTION
If the subclass is missing `Class::table_name` `__call` would be called, in turn calling `__get` which needs `Class::table_name` to work, repeat. Result is infinite recursion and a PHP segmentation fault.

**Steps to reproduce:**
1. Create class extending BasicObject
2. Don't implement `Class::table_name`
3. `$foo = new Class()`

**Expected results**
Call to undefined function Class::table_name

**Actual results**

```
[Sun Feb 24 04:40:37 2013] [notice] child pid 4913 exit signal Segmentation fault (11)
```
